### PR TITLE
Dynamic actions & popInitialAction

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,44 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# http://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+#Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+node_modules/**/*

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Support for the new Touch 3D home screen quick actions for your React Native app
 
 ![](http://i.imgur.com/holmBPD.png)
 
-_NOTE_: At this time only static quick actions are supported!
-
 ## Installing
 
 First cd into your project's directory and grab the latest version of this code:
@@ -15,16 +13,10 @@ First cd into your project's directory and grab the latest version of this code:
 $ npm install react-native-quick-actions --save
 ```
 
-In XCode add the library from `node_modules/react-native-quick-actions/RNQuickAction.xcodeproj` to your project then add `libRNQuickAction` to your project's __Build Phase__ > __Link Binary With Libraries__ list.
+## Usage
 
-![adding to XCode](http://brentvatne.ca/images/packaging/7-add-link.gif)
-
-Next you need to add tell XCode where it can find the RNQuickAction source.
-Open up the project, add
-`$(SRCROOT)/node_modules/react-native-quick-actions/RNQuickAction` to your
-Header Search Paths and make sure it's `recursive`.
-
-![](http://brentvatne.ca/images/packaging/4-header-search-paths.png)
+### Linking the Library
+In order to use quick actions you must first link the library to your project.  There's excellent documentation on how to do this in the [React Native Docs](http://facebook.github.io/react-native/docs/linking-libraries-ios.html#content). Make sure you do all steps including #3
 
 Lastly, add the following lines to your `AppDelegate.m` file:
 
@@ -36,7 +28,7 @@ Lastly, add the following lines to your `AppDelegate.m` file:
 }
 ```
 
-## Adding static quick actions
+### Adding static quick actions
 
 This part is pretty easy. There are a [bunch of
 tutorials](https://littlebitesofcocoa.com/79) and
@@ -47,6 +39,7 @@ Add these entries into to your `Info.plist` file and replace the generic stuff
 (Action Title, .action, etc):
 
 ```xml
+<key>UIApplicationShortcutItems</key>
 <array>
   <dict>
     <key>UIApplicationShortcutItemIconType</key>
@@ -65,7 +58,7 @@ A full list of available icons can be found here:
 
 _NOTE_: A bunch of these icons are iOS 9.1 only so YMMV on 9.0 devices.
 
-## Adding dynamic quick actions
+### Adding dynamic quick actions
 
 In order to add / remove dynamic actions during application lifecycle, you need to require `react-native-quick-actions` and call either `setShortcutItems` or `clearShortcutItems` (useful when user is logging out).
 
@@ -78,7 +71,7 @@ QuickActions.setShortcutItems([
     type: "Orders", // Required
     title: "See your orders", // Optional, if empty, `type` will be used instead
     subtitle: "See orders you've made",
-    icon: "compose" // Pass any of UIApplicationShortcutIconType<name>
+    icon: "Compose", // Pass any of UIApplicationShortcutIconType<name>
     userInfo: {
       url: "app://orders" // provide custom data, like in-app url you want to open
     }
@@ -89,11 +82,11 @@ QuickActions.setShortcutItems([
 QuickActions.clearShortcutItems();
 ```
 
-In order to specify icon for your shortcut item, either include `UIApplicationShortcutIconType<name>`, e.g. for `UIApplicationShortcutIconTypeCompose` go with `compose` or define your asset name if you want to use image from a template (e.g. `my-custom-icon` if that's the name of image in `Images.xcassets`. Remember not to name your custom icons with any of `compose`, `play`, `pause`, `add`, `location`, `search` and `share`, otherwise system ones will be loaded instead).
+In order to specify icon for your shortcut item, either include `UIApplicationShortcutIconType<name>`, e.g. for `UIApplicationShortcutIconTypeCompose` go with `Compose` or define your asset name if you want to use image from a template (e.g. `my-custom-icon` if that's the name of image in `Images.xcassets`. Remember not to name your custom icons the same as any system icons otherwise system ones will be loaded instead).
 
 Full list of available icons has been already listed in the previous section.
 
-## Listening for quick actions in your javascript code
+### Listening for quick actions in your javascript code
 
 First, you'll need to make sure `DeviceEventEmitter` is added to the list of
 requires for React.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Header Search Paths and make sure it's `recursive`.
 Lastly, add the following lines to your `AppDelegate.m` file:
 
 ```obj-c
-#import "RNQuickAction.h"
+#import "RNQuickActionManager.h"
 
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void (^)(BOOL succeeded)) completionHandler {
-  [RNQuickAction onQuickActionPress:shortcutItem completionHandler:completionHandler];
+  [RNQuickActionManager onQuickActionPress:shortcutItem completionHandler:completionHandler];
 }
 ```
 
@@ -94,9 +94,10 @@ To get any actions sent when the app is cold-launched using the following code:
 
 ```js
 var QuickActions = require('react-native-quick-actions');
-var data = QuickActions.popInitialGesture();
-
-doSomethingWithTheGesture(data);
+var action = QuickActions.popInitialAction();
+if (action) {
+  doSomethingWithTheAction(action); // e.g. LinkingIOS.openURL(..)
+}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -65,6 +65,34 @@ A full list of available icons can be found here:
 
 _NOTE_: A bunch of these icons are iOS 9.1 only so YMMV on 9.0 devices.
 
+## Adding dynamic quick actions
+
+In order to add / remove dynamic actions during application lifecycle, you need to require `react-native-quick-actions` and call either `setShortcutItems` or `clearShortcutItems` (useful when user is logging out).
+
+```js
+var QuickActions = require('react-native-quick-actions');
+
+// Add few actions
+QuickActions.setShortcutItems([
+  {
+    type: "Orders", // Required
+    title: "See your orders", // Optional, if empty, `type` will be used instead
+    subtitle: "See orders you've made",
+    icon: "compose" // Pass any of UIApplicationShortcutIconType<name>
+    userInfo: {
+      url: "app://orders" // provide custom data, like in-app url you want to open
+    }
+  }
+]);
+
+// Clear them all
+QuickActions.clearShortcutItems();
+```
+
+In order to specify icon for your shortcut item, either include `UIApplicationShortcutIconType<name>`, e.g. for `UIApplicationShortcutIconTypeCompose` go with `compose` or define your asset name if you want to use image from a template (e.g. `my-custom-icon` if that's the name of image in `Images.xcassets`. Remember not to name your custom icons with any of `compose`, `play`, `pause`, `add`, `location`, `search` and `share`, otherwise system ones will be loaded instead).
+
+Full list of available icons has been already listed in the previous section.
+
 ## Listening for quick actions in your javascript code
 
 First, you'll need to make sure `DeviceEventEmitter` is added to the list of

--- a/RNQuickAction/RNQuickAction.xcodeproj/project.pbxproj
+++ b/RNQuickAction/RNQuickAction.xcodeproj/project.pbxproj
@@ -7,8 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		91090D8F1BB6C934009AE358 /* RNQuickAction.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 91090D8E1BB6C934009AE358 /* RNQuickAction.h */; };
-		91090D911BB6C934009AE358 /* RNQuickAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 91090D901BB6C934009AE358 /* RNQuickAction.m */; };
+		AD90517D1BD2EE4A00EFDEBC /* RNQuickActionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AD90517B1BD2EE4A00EFDEBC /* RNQuickActionManager.m */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -18,7 +17,6 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
-				91090D8F1BB6C934009AE358 /* RNQuickAction.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -26,8 +24,8 @@
 
 /* Begin PBXFileReference section */
 		91090D8B1BB6C934009AE358 /* libRNQuickAction.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNQuickAction.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		91090D8E1BB6C934009AE358 /* RNQuickAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNQuickAction.h; sourceTree = "<group>"; };
-		91090D901BB6C934009AE358 /* RNQuickAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNQuickAction.m; sourceTree = "<group>"; };
+		AD90517B1BD2EE4A00EFDEBC /* RNQuickActionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNQuickActionManager.m; sourceTree = "<group>"; };
+		AD90517C1BD2EE4A00EFDEBC /* RNQuickActionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNQuickActionManager.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,8 +58,8 @@
 		91090D8D1BB6C934009AE358 /* RNQuickAction */ = {
 			isa = PBXGroup;
 			children = (
-				91090D8E1BB6C934009AE358 /* RNQuickAction.h */,
-				91090D901BB6C934009AE358 /* RNQuickAction.m */,
+				AD90517B1BD2EE4A00EFDEBC /* RNQuickActionManager.m */,
+				AD90517C1BD2EE4A00EFDEBC /* RNQuickActionManager.h */,
 			);
 			path = RNQuickAction;
 			sourceTree = "<group>";
@@ -123,7 +121,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				91090D911BB6C934009AE358 /* RNQuickAction.m in Sources */,
+				AD90517D1BD2EE4A00EFDEBC /* RNQuickActionManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -167,7 +165,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../node_modules/react-native/React/**";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -205,7 +203,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/../node_modules/react-native/React/**";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -219,6 +217,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -232,6 +231,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.h
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.h
@@ -8,6 +8,6 @@
 
 #import "RCTBridgeModule.h"
 
-@interface RNQuickAction : NSObject <RCTBridgeModule>
+@interface RNQuickActionManager : NSObject <RCTBridgeModule>
 +(void) onQuickActionPress:(UIApplicationShortcutItem *) shortcutItem completionHandler:(void (^)(BOOL succeeded)) completionHandler;
 @end

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -56,14 +56,16 @@ RCT_EXPORT_MODULE();
 
 // Map user passed array of UIApplicationShortcutItem
 - (NSArray*)dynamicShortcutItemsForPassedArray:(NSArray*)passedArray {
+    // FIXME: Dynamically map icons from UIApplicationShortcutIconType to / from their string counterparts
+    // so we don't have to update this list every time Apple adds new system icons.
     NSDictionary *icons = @{
-        @"compose": @(UIApplicationShortcutIconTypeCompose),
-        @"play": @(UIApplicationShortcutIconTypePlay),
-        @"pause": @(UIApplicationShortcutIconTypePause),
-        @"add": @(UIApplicationShortcutIconTypeAdd),
-        @"location": @(UIApplicationShortcutIconTypeLocation),
-        @"search": @(UIApplicationShortcutIconTypeSearch),
-        @"share": @(UIApplicationShortcutIconTypeShare)
+        @"Compose": @(UIApplicationShortcutIconTypeCompose),
+        @"Play": @(UIApplicationShortcutIconTypePlay),
+        @"Pause": @(UIApplicationShortcutIconTypePause),
+        @"Add": @(UIApplicationShortcutIconTypeAdd),
+        @"Location": @(UIApplicationShortcutIconTypeLocation),
+        @"Search": @(UIApplicationShortcutIconTypeSearch),
+        @"Share": @(UIApplicationShortcutIconTypeShare)
     };
     
     NSMutableArray *shortcutItems = [NSMutableArray new];

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -86,7 +86,7 @@ RCT_EXPORT_MODULE();
                                                                   localizedTitle:item[@"title"] ?: item[@"type"]
                                                                localizedSubtitle:item[@"subtitle"]
                                                                             icon:shortcutIcon
-                                                                        userInfo:item[@"userInfo"]];
+                                                                        userInfo:item[@"userInfo"]]];
     }];
     
     return shortcutItems;

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -55,7 +55,7 @@ RCT_EXPORT_MODULE();
 }
 
 // Map user passed array of UIApplicationShortcutItem
-- (NSArray*)dynamicShortcutIconsForPassedArray:(NSArray*)passedArray {
+- (NSArray*)dynamicShortcutItemsForPassedArray:(NSArray*)passedArray {
     NSDictionary *icons = @{
         @"compose": @(UIApplicationShortcutIconTypeCompose),
         @"play": @(UIApplicationShortcutIconTypePlay),
@@ -94,7 +94,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(setShortcutItems:(NSArray *) shortcutItems)
 {
-    NSArray *dynamicShortcuts = [self dynamicShortcutIconsForPassedArray:shortcutItems];
+    NSArray *dynamicShortcuts = [self dynamicShortcutItemsForPassedArray:shortcutItems];
     [UIApplication sharedApplication].shortcutItems = dynamicShortcuts;
 }
 

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -54,6 +54,55 @@ RCT_EXPORT_MODULE();
     _initialAction = [bridge.launchOptions[UIApplicationLaunchOptionsShortcutItemKey] copy];
 }
 
+// Map user passed array of UIApplicationShortcutItem
+- (NSArray*)dynamicShortcutIconsForPassedArray:(NSArray*)passedArray {
+    NSDictionary *icons = @{
+        @"compose": @(UIApplicationShortcutIconTypeCompose),
+        @"play": @(UIApplicationShortcutIconTypePlay),
+        @"pause": @(UIApplicationShortcutIconTypePause),
+        @"add": @(UIApplicationShortcutIconTypeAdd),
+        @"location": @(UIApplicationShortcutIconTypeLocation),
+        @"search": @(UIApplicationShortcutIconTypeSearch),
+        @"share": @(UIApplicationShortcutIconTypeShare)
+    };
+    
+    NSMutableArray *shortcutItems = [NSMutableArray new];
+    
+    [passedArray enumerateObjectsUsingBlock:^(NSDictionary *item, NSUInteger idx, BOOL *stop) {
+        NSString *iconName = item[@"icon"];
+        
+        // If passed iconName is enum, use system icon
+        // Otherwise, load from bundle
+        UIApplicationShortcutIcon *shortcutIcon;
+        NSNumber *iconType = icons[iconName];
+        
+        if (iconType) {
+            shortcutIcon = [UIApplicationShortcutIcon iconWithType:[iconType intValue]];
+        } else if (iconName) {
+            shortcutIcon = [UIApplicationShortcutIcon iconWithTemplateImageName:iconName];
+        }
+        
+        [shortcutItems addObject:[[UIApplicationShortcutItem alloc] initWithType:item[@"type"]
+                                                                  localizedTitle:item[@"title"] ?: item[@"type"]
+                                                               localizedSubtitle:item[@"subtitle"]
+                                                                            icon:shortcutIcon
+                                                                        userInfo:item[@"userInfo"]];
+    }];
+    
+    return shortcutItems;
+}
+
+RCT_EXPORT_METHOD(setShortcutItems:(NSArray *) shortcutItems)
+{
+    NSArray *dynamicShortcuts = [self dynamicShortcutIconsForPassedArray:shortcutItems];
+    [UIApplication sharedApplication].shortcutItems = dynamicShortcuts;
+}
+
+RCT_EXPORT_METHOD(clearShortcutItems)
+{
+    [UIApplication sharedApplication].shortcutItems = nil;
+}
+
 + (void)onQuickActionPress:(UIApplicationShortcutItem *) shortcutItem completionHandler:(void (^)(BOOL succeeded)) completionHandler
 {
     RCTLogInfo(@"[RNQuickAction] Quick action shortcut item pressed: %@", [shortcutItem type]);

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,17 +1,17 @@
-var RNQuickActionManager = require('react-native').NativeModules.RNQuickAction;
-var _initialGesture = RNQuickActionManager.initialGesture;
+var RNQuickActionManager = require('react-native').NativeModules.RNQuickActionManager;
+var _initialAction = RNQuickActionManager.initialAction;
 
 module.exports = {
   /**
-   * An initial gesture will be available if the app was cold-launched
-   * from a gesture.
+   * An initial action will be available if the app was cold-launched
+   * from an action.
    *
-   * The first caller of `popInitialGesture` will get the initial
-   * gesture object, or `null`. Subsequent invocations will return null.
+   * The first caller of `popInitialAction` will get the initial
+   * action object, or `null`. Subsequent invocations will return null.
    */
-  popInitialGesture: function () {
-    var initialGesture = _initialGesture;
-    _initialGesture = null;
-    return initialGesture;
+  popInitialAction: function () {
+    var initialAction = _initialAction;
+    _initialAction = null;
+    return initialAction;
   }
 };

--- a/index.ios.js
+++ b/index.ios.js
@@ -13,5 +13,19 @@ module.exports = {
     var initialAction = _initialAction;
     _initialAction = null;
     return initialAction;
+  },
+  
+  /**
+   * Adds shortcut items to application
+   */
+  setShortcutItems: function(icons) {
+    RNQuickActionManager.setShortcutItems(icons);
+  },
+  
+  /**
+   * Clears all previously set dynamic icons
+   */
+  clearShortcutItems: function() {
+    RNQuickActionManager.clearShortcutItems();
   }
 };


### PR DESCRIPTION
Thanks for adding me to contributors, I've decided to make a branch here to make it easier to work on the updates.

This pull request <s>is still WIP and requires some on-device testing, but it</s> essentially does two things:
- it renames gesture to action
- it encapsulates `UIApplicationShortcutItem` to `NSDictionary` conversion into a separate ReactNative like method.
- it renames RNQuickAction to RNQuickActionManager (it's better and aligns with React Native as well as with our Javascript bindings)
- RNQuickAction is action by itself.
- User can now specify dynamic actions by providing an array of shortcut icon objects

Tested on iOS Simulator, iPhone 6s and in my production app.