### PR TITLE
Support older iOS versions

### DIFF
--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -13,6 +13,7 @@
 #import "RCTUtils.h"
 
 NSString *const RCTShortcutItemClicked = @"ShortcutItemClicked";
+BOOL RCTShortcutsAvailable = false;
 
 NSDictionary *RNQuickAction(UIApplicationShortcutItem *item) {
     if (!item) return nil;
@@ -31,6 +32,10 @@ NSDictionary *RNQuickAction(UIApplicationShortcutItem *item) {
 RCT_EXPORT_MODULE();
 
 @synthesize bridge = _bridge;
+
++ (void)initialize {
+    RCTShortcutsAvailable = [UIApplicationShortcutItem class] != nil;
+}
 
 - (instancetype)init
 {
@@ -51,7 +56,7 @@ RCT_EXPORT_MODULE();
 - (void)setBridge:(RCTBridge *)bridge
 {
     _bridge = bridge;
-    if ([UIApplicationShortcutItem class]) {
+    if (RCTShortcutsAvailable) {
         _initialAction = [bridge.launchOptions[UIApplicationLaunchOptionsShortcutItemKey] copy];
     }
 }
@@ -98,7 +103,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)
 {
-    if ([UIApplicationShortcutItem class]) {
+    if (RCTShortcutsAvailable) {
         return callback(@[[NSNull null]]);
     } else {
         return callback(@[RCTMakeError(@"[RNQuickActions] UIApplication shortcuts are not available.", nil, nil)]);
@@ -107,7 +112,7 @@ RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(setShortcutItems:(NSArray *) shortcutItems)
 {
-    if ([UIApplicationShortcutItem class]) {
+    if (RCTShortcutsAvailable) {
         NSArray *dynamicShortcuts = [self dynamicShortcutItemsForPassedArray:shortcutItems];
         [UIApplication sharedApplication].shortcutItems = dynamicShortcuts;
     }
@@ -115,7 +120,7 @@ RCT_EXPORT_METHOD(setShortcutItems:(NSArray *) shortcutItems)
 
 RCT_EXPORT_METHOD(clearShortcutItems)
 {
-    if ([UIApplicationShortcutItem class]) {
+    if (RCTShortcutsAvailable) {
         [UIApplication sharedApplication].shortcutItems = nil;
     }
 }

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -96,6 +96,15 @@ RCT_EXPORT_MODULE();
     return shortcutItems;
 }
 
+RCT_EXPORT_METHOD(isAvailable:(RCTResponseSenderBlock)callback)
+{
+    if ([UIApplicationShortcutItem class]) {
+        return callback(@[[NSNull null]]);
+    } else {
+        return callback(@[RCTMakeError(@"[RNQuickActions] UIApplication shortcuts are not available.", nil, nil)]);
+    }
+}
+
 RCT_EXPORT_METHOD(setShortcutItems:(NSArray *) shortcutItems)
 {
     if ([UIApplicationShortcutItem class]) {

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -51,7 +51,9 @@ RCT_EXPORT_MODULE();
 - (void)setBridge:(RCTBridge *)bridge
 {
     _bridge = bridge;
-    _initialAction = [bridge.launchOptions[UIApplicationLaunchOptionsShortcutItemKey] copy];
+    if ([UIApplicationShortcutItem class]) {
+        _initialAction = [bridge.launchOptions[UIApplicationLaunchOptionsShortcutItemKey] copy];
+    }
 }
 
 // Map user passed array of UIApplicationShortcutItem

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -98,13 +98,17 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(setShortcutItems:(NSArray *) shortcutItems)
 {
-    NSArray *dynamicShortcuts = [self dynamicShortcutItemsForPassedArray:shortcutItems];
-    [UIApplication sharedApplication].shortcutItems = dynamicShortcuts;
+    if ([UIApplicationShortcutItem class]) {
+        NSArray *dynamicShortcuts = [self dynamicShortcutItemsForPassedArray:shortcutItems];
+        [UIApplication sharedApplication].shortcutItems = dynamicShortcuts;
+    }
 }
 
 RCT_EXPORT_METHOD(clearShortcutItems)
 {
-    [UIApplication sharedApplication].shortcutItems = nil;
+    if ([UIApplicationShortcutItem class]) {
+        [UIApplication sharedApplication].shortcutItems = nil;
+    }
 }
 
 + (void)onQuickActionPress:(UIApplicationShortcutItem *) shortcutItem completionHandler:(void (^)(BOOL succeeded)) completionHandler

--- a/index.ios.js
+++ b/index.ios.js
@@ -16,6 +16,26 @@ module.exports = {
   },
   
   /**
+   * Check if UIApplication Shortcuts are available
+   */
+  isAvailable: function(callback) {
+    return new Promise(function(resolve, reject) {
+      RNQuickActionManager.isAvailable(function(error) {
+        if (error) {
+          if (callback) {
+            callback(false, error);
+          }
+          return reject(error);
+        }
+        if (callback) {
+          callback(true, error);
+        }
+        resolve(true);
+      });
+    });
+  },
+  
+  /**
    * Adds shortcut items to application
    */
   setShortcutItems: function(icons) {


### PR DESCRIPTION
Calling `UIApplicationLaunchOptionsShortcutItemKey` on older iOS versions (iOS 8) causes a crash. I've added a simple check to be sure Application shortcuts is available.
