### PR TITLE
Remove react-native peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,5 @@
   "license": "MIT",
   "devDependencies": {
     "react-native": "^0.11.2"
-  },
-  "peerDependencies": {
-    "react-native": "0.*"
   }
 }


### PR DESCRIPTION
The react-native peerDependency is not locked down to any specific version and will cause npm to throw errors if using with any release candidate. NPM 3 mostly obsoletes the `peerDependencies` setting and many modules are moving to skipping entirely.