### PR TITLE
[Android] Use PersistableBundle to persist the whole ShortCutItem object

### DIFF
--- a/android/src/main/java/com/reactNativeQuickActions/ShortcutItem.java
+++ b/android/src/main/java/com/reactNativeQuickActions/ShortcutItem.java
@@ -1,5 +1,7 @@
 package com.reactNativeQuickActions;
 
+import android.os.PersistableBundle;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
@@ -17,6 +19,24 @@ class ShortcutItem {
         item.icon = map.getString("icon");
         item.userInfo = UserInfo.fromReadableMap(map.getMap("userInfo"));
         return item;
+    }
+
+    static ShortcutItem fromPersistableBundle(PersistableBundle bundle) {
+        final ShortcutItem item = new ShortcutItem();
+        item.type = bundle.getString("type");
+        item.title = bundle.getString("title");
+        item.icon = bundle.getString("icon");
+        item.userInfo = UserInfo.fromPersistableBundle(bundle.getPersistableBundle("userInfo"));
+        return item;
+    }
+
+    PersistableBundle toPersistableBundle() {
+        PersistableBundle bundle = new PersistableBundle();
+        bundle.putString("type", type);
+        bundle.putString("title", title);
+        bundle.putString("icon", icon);
+        bundle.putPersistableBundle("userInfo", userInfo.toPersistableBundle());
+        return bundle;
     }
 
     WritableMap toWritableMap() {

--- a/android/src/main/java/com/reactNativeQuickActions/UserInfo.java
+++ b/android/src/main/java/com/reactNativeQuickActions/UserInfo.java
@@ -1,5 +1,7 @@
 package com.reactNativeQuickActions;
 
+import android.os.PersistableBundle;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
@@ -12,6 +14,18 @@ class UserInfo {
         final UserInfo info = new UserInfo();
         info.url = map.getString("url");
         return info;
+    }
+
+    static UserInfo fromPersistableBundle(PersistableBundle bundle) {
+        final UserInfo info = new UserInfo();
+        info.url = bundle.getString("url");
+        return info;
+    }
+
+    PersistableBundle toPersistableBundle() {
+        PersistableBundle bundle = new PersistableBundle();
+        bundle.putString("url", url);
+        return bundle;
     }
 
     WritableMap toWritableMap() {


### PR DESCRIPTION
Fixes: #51 

Pro's:
1. In memory list mShortcutItems is no longer needed.
2. 'Type' is technically useless now but I think we should leave it to distinguish each shortcut.
3. Method: getShortcutItem is no longer needed since the whole object is persisted, not just type.
4. The whole object persists on COLD APP launch, now consistent with iOS version.

Cons:
- I believe we need to set the minimumSDK to 21 since [PersistableBundle](https://developer.android.com/reference/android/os/PersistableBundle.html) was only added then but because quick actions on Android are only supported on Android 7.1 (25) and after, this should be fine?

This should cause no regression but I am not 100%  sure whether iOS returns the whole object like this.

Let me know what you think,

Alberto Blanco