### PR TITLE
fix: 3D Touch will be responsed twice when the app is cold-launched 

### DIFF
--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -123,6 +123,11 @@ RCT_EXPORT_MODULE();
     return shortcutItems;
 }
 
+RCT_EXPORT_METHOD(getInitialAction:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve(_shortcutItem);
+}
+
 RCT_EXPORT_METHOD(setShortcutItems:(NSArray *) shortcutItems)
 {
     NSArray *dynamicShortcuts = [self dynamicShortcutItemsForPassedArray:shortcutItems];
@@ -157,13 +162,6 @@ RCT_EXPORT_METHOD(clearShortcutItems)
     _shortcutItem = notification.userInfo;
     [_bridge.eventDispatcher sendDeviceEventWithName:@"quickActionShortcut"
                                                 body:_shortcutItem];
-}
-
-- (NSDictionary *)constantsToExport
-{
-    return @{
-      @"initialAction": RCTNullIfNil(_shortcutItem)
-    };
 }
 
 @end

--- a/RNQuickAction/RNQuickAction/RNQuickActionManager.m
+++ b/RNQuickAction/RNQuickAction/RNQuickActionManager.m
@@ -25,7 +25,7 @@ NSDictionary *RNQuickAction(UIApplicationShortcutItem *item) {
 
 @implementation RNQuickActionManager
 {
-    UIApplicationShortcutItem *_initialAction;
+    NSDictionary *_shortcutItem;
 }
 
 RCT_EXPORT_MODULE();
@@ -59,7 +59,6 @@ RCT_EXPORT_MODULE();
 - (void)setBridge:(RCTBridge *)bridge
 {
     _bridge = bridge;
-    _initialAction = [bridge.launchOptions[UIApplicationLaunchOptionsShortcutItemKey] copy];
 }
 
 // Map user passed array of UIApplicationShortcutItem
@@ -155,14 +154,15 @@ RCT_EXPORT_METHOD(clearShortcutItems)
 
 - (void)handleQuickActionPress:(NSNotification *) notification
 {
+    _shortcutItem = notification.userInfo;
     [_bridge.eventDispatcher sendDeviceEventWithName:@"quickActionShortcut"
-                                                body:notification.userInfo];
+                                                body:_shortcutItem];
 }
 
 - (NSDictionary *)constantsToExport
 {
     return @{
-      @"initialAction": RCTNullIfNil(RNQuickAction(_initialAction))
+      @"initialAction": RCTNullIfNil(_shortcutItem)
     };
 }
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,5 +1,4 @@
 var RNQuickActionManager = require('react-native').NativeModules.RNQuickActionManager;
-var _initialAction = RNQuickActionManager && RNQuickActionManager.initialAction;
 
 module.exports = {
   /**
@@ -10,11 +9,7 @@ module.exports = {
    * action object, or `null`. Subsequent invocations will return null.
    */
   popInitialAction: function() {
-    return new Promise((resolve) => {
-      var initialAction = _initialAction;
-      _initialAction = null;
-      resolve(initialAction);
-    })
+    return RNQuickActionManager.getInitialAction();
   },
 
   /**


### PR DESCRIPTION
like this:

```
QuickActions.popInitialAction().then(quickActionsHandler);
DeviceEventEmitter.addListener('quickActionShortcut', quickActionsHandler);
```

quickActionsHandler will be called twice