### PR TITLE
[Android] Cold launch 2 quick actions after each other doesn't trigger listener.

### DIFF
--- a/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
+++ b/android/src/main/java/com/reactNativeQuickActions/AppShortcutsModule.java
@@ -106,6 +106,7 @@ class AppShortcutsModule extends ReactContextBaseJavaModule {
                     .getIdentifier(item.icon, "drawable", context.getPackageName());
             Intent intent = new Intent(context, currentActivity.getClass());
             intent.setAction(ACTION_SHORTCUT);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             intent.putExtra(SHORTCUT_TYPE, item.type);
 
             shortcuts.add(new ShortcutInfo.Builder(context, "id" + i)


### PR DESCRIPTION
When you preform a quick action from cold launch, then close the application and do another quick action the listeners aren't triggered on Android since the app isn't cleared. On iOS it already does that.

My commit makes Android always run from a clean slate on every quick action.

Is it possible to make a new npm build after this?

Thanks!
Diemas Michiels