### PR TITLE
Fix Android Gradle "compile" deprecation warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,5 +11,5 @@ android {
 }
 
 dependencies {
-    provided "com.facebook.react:react-native:+"
+    api "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
Since RN 0.57 the android build tools were updated from 2.3.3 to v3.1 (https://github.com/facebook/react-native/commit/6eac2d4)

When using `compile` in the build.gradle file it generates the following error:
`WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html`

I have changed the config from `provided` to `api`, the same as most react native libraries:
- https://github.com/react-native-community/react-native-device-info/pull/520
- https://github.com/react-native-community/react-native-netinfo/blob/master/android/build.gradle#L41
- https://github.com/react-native-community/react-native-webview/blob/master/android/build.gradle#L127